### PR TITLE
Added fix to prevent the overflow of the 16-bit 'identification' bit.

### DIFF
--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -258,7 +258,12 @@ class Ping(object):
 
         global _next_id
         self.ID = _next_id
-        _next_id += 1
+
+        # This is required to prevent the overflow of the 16-bit 'identification' bit.
+        if _next_id == 65535:
+            _next_id = 0
+        else:
+            _next_id += 1
 
         if self.destIP is None:
             if hostname is None:


### PR DESCRIPTION
Hi,
I'm using the library to do long term pinging, but after a few hours, a struct exception came, it turned out, that it happened, when the identification field (16bit) overflowed.

I fixed it with a simple check, if the bits in the field are maxed out, it starts from zero again.